### PR TITLE
Add header packages to dev instructions

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -11,6 +11,10 @@ set up the `DataStore`_.
 Development installation
 ========================
 
+Install the required packages::
+
+    sudo apt-get install python-dev python-virtualenv build-essential libxslt1-dev libxml2-dev git
+
 Get the code::
 
     git clone https://github.com/ckan/datapusher


### PR DESCRIPTION
When following docs to install CKAN + Data Store|Pusher in a fresh VM you get to these instructions w/out the required header files...
