### PR TITLE
Add dependencies needed by python requests for SNI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
 install:
   - pip install -r requirements-dev.txt
   - pip install .
-  - pip install coveralls --use-mirrors
+  - pip install coveralls
 script: nosetests --with-coverage --cover-package=datapusher
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - "2.7"
 install:
+  - pip install --force-reinstall --upgrade https://pypi.python.org/packages/source/p/pip/pip-1.5.6.tar.gz
   - pip install -r requirements-dev.txt
   - pip install .
   - pip install coveralls

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -14,7 +14,7 @@ Development installation
 
 Install the required packages::
 
-    sudo apt-get install python-dev python-virtualenv build-essential libxslt1-dev libxml2-dev git
+    sudo apt-get install python-dev python-virtualenv build-essential libxslt1-dev libxml2-dev git libffi-dev
 
 Get the code::
 
@@ -59,7 +59,7 @@ These instructions set up the |datapusher| webservice on Apache running on port 
 ::
 
     #install requirements for the DataPusher
-    sudo apt-get install python-dev python-virtualenv build-essential libxslt1-dev libxml2-dev git
+    sudo apt-get install python-dev python-virtualenv build-essential libxslt1-dev libxml2-dev git libffi-dev
 
     #create a virtualenv for datapusher
     sudo virtualenv /usr/lib/ckan/datapusher

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
 https://github.com/okfn/ckan-service-provider/archive/stable.zip
 messytables>=0.12.0
 python-slugify
-Requests
+requests
+ndg-httpsclient
+pyasn1
+pyOpenSSL


### PR DESCRIPTION
The default python requests library for python2 is not able to handle
SNI enabled sites (sites with multiple https configurations per IP, see
https://en.wikipedia.org/wiki/Server_Name_Indication for more info).

To correct this, one needs to install pyOpenSSL, ndg-httpsclient and
pyasn1 (recommended packages for urllib3 in some distros, e.g. debian -
https://packages.debian.org/sid/python-urllib3 )
