### PR TITLE
Strip column names

### DIFF
--- a/datapusher/jobs.py
+++ b/datapusher/jobs.py
@@ -282,16 +282,17 @@ def push_to_datastore(task_id, input, dry_run=False):
     types = messytables.type_guess(row_set.sample, types=TYPES, strict=True)
     row_set.register_processor(messytables.types_processor(types))
 
-    headers = [header for header in headers if header]
+    headers = [header.strip() for header in headers if header.strip()]
     headers_set = set(headers)
 
     def row_iterator():
         for row in row_set:
             data_row = {}
             for index, cell in enumerate(row):
-                if cell.column not in headers_set:
+                column_name = cell.column.strip()
+                if column_name not in headers_set:
                     continue
-                data_row[cell.column] = cell.value
+                data_row[column_name] = cell.value
             yield data_row
     result = row_iterator()
 


### PR DESCRIPTION
As per #46:

It is very easy to create column names that include spaces, in particular when hand-typing CSV data:

my field, my other field, a third field
value one, value two, value three

This will create fields named " my other field" and " a third field". Having field names that start/end with spaces causes a lot of complications, because some code strips the field names, while others don't. This is particularly true when using third party libraries, and parsing text-representations of strings such as the sort string "my field ASC, my other field DESC", etc.

See for instance: https://github.com/ckan/ckan/issues/1970

Given that there is no practical use for having field names that start or end with spaces (these will be just as confusing to humans as they are to machines), I suggest the datapusher should strip field names. (And, accordingly, CKAN datastore API should refuse field names that start/end with spaces).
