### PR TITLE
Added Dockerfile & Fig definition

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,2 @@
+FROM python:2.7.8-onbuild
+CMD [ "python", "datapusher/main.py", "deployment/datapusher_settings.py"]

--- a/fig.yml
+++ b/fig.yml
@@ -1,0 +1,5 @@
+datapusher:
+  build: .
+  hostname: datapusher
+  ports:
+    - "8800:8800"


### PR DESCRIPTION
Hi,

I've added a  Dockerfile & Fig definition to run the datapusher in a Docker container.
This is going to be needed for the upcoming ckan-docker config.

I've already tested it and I've got it built on the docker hub until it's available under the CKAN organisation.
https://registry.hub.docker.com/u/clementmouchet/datapusher/

Cheers,

Clement
