### PR TITLE
Adding 'pdftables' as a requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ messytables>=0.12.0
 python-slugify
 Requests
 argparse
+pdftables


### PR DESCRIPTION
`pdftables` is needed in order to upload PDF files into DataStore.