### PR TITLE
Allows configuration of maximum file size to be configured.

### DIFF
--- a/datapusher/jobs.py
+++ b/datapusher/jobs.py
@@ -21,12 +21,12 @@ from slugify import slugify
 
 import ckanserviceprovider.job as job
 import ckanserviceprovider.util as util
-from ckanserviceprovider import web 
+from ckanserviceprovider import web
 
 if not locale.getlocale()[0]:
     locale.setlocale(locale.LC_ALL, '')
 
-MAX_CONTENT_LENGTH = 10485760  # 10MB
+MAX_CONTENT_LENGTH = web.app.config.get('MAX_CONTENT_LENGTH') or 10485760
 DOWNLOAD_TIMEOUT = 30
 
 _TYPE_MAPPING = {

--- a/doc/using.rst
+++ b/doc/using.rst
@@ -26,12 +26,23 @@ If you want to retry an upload go into the resource edit form in CKAN and
 just click the "Update" button to resubmit the resource metadata.
 This will retrigger an upload.
 
+
+Configuring the maximum upload size
+-----------------------------------
+
+By default the ``datapusher`` will only attempt to process files less than 10Mb
+in size.  To change this value you can specify the MAX_CONTENT_LENGTH setting in
+datapusher_settings.py
+
+    MAX_CONTENT_LENGTH = 1024  # 1Kb maximum size
+
+
 Configuring the guessing of types
 ---------------------------------
 
-The ``datapusher`` uses Messytables_ in order to infer data types. A default 
+The ``datapusher`` uses Messytables_ in order to infer data types. A default
 configuration is provided which is sufficient in many cases. Depending on your
-data however, you may need to implement your own ``Messytables`` types. 
+data however, you may need to implement your own ``Messytables`` types.
 
 You can specify the types to use with the following settings in your datapusher_settings.py::
 


### PR DESCRIPTION
The default is 10mb, but this PR allows a larger (or smaller)
value to be specified in the datapusher_settings.py file.

Complete with documentation

This should close #79 