### PR TITLE
Check for datastore url_type

### DIFF
--- a/datapusher/jobs.py
+++ b/datapusher/jobs.py
@@ -283,6 +283,11 @@ def push_to_datastore(task_id, input, dry_run=False):
         #try again in 5 seconds just incase CKAN is slow at adding resource
         time.sleep(5)
         resource = get_resource(resource_id, ckan_url, api_key)
+        
+    # check if the resource url_type is a datastore
+    if resource.get('url_type') == 'datastore':
+        logger.info('Dump files are managed with the Datastore API')
+        return
 
     # fetch the resource data
     logger.info('Fetching from: {0}'.format(resource.get('url')))


### PR DESCRIPTION
When you update a resource with the `resource_update` or `resource_patch` API, the datapusher attempts to re-run on the /datastore/dump URL which is by default not a valid URL (i.e. "/datastore/dump/adab91ac-7c08-4837-aca1-31e8efcd9124").
