### PR TITLE
Added missing package zlib1g-dev required to install python requirements.

### DIFF
--- a/doc/development.rst
+++ b/doc/development.rst
@@ -3,7 +3,7 @@ Development installation
 
 Install the required packages::
 
-    sudo apt-get install python-dev python-virtualenv build-essential libxslt1-dev libxml2-dev git
+    sudo apt-get install python-dev python-virtualenv build-essential libxslt1-dev libxml2-dev zlib1g-dev git
 
 Get the code::
 


### PR DESCRIPTION
Runing Ubuntu 14.04 got an error when installing python requirements.

When installing lxml an error was given asking to make sure development packages of libxml2 and libxslt are installed.
