### PR TITLE
Get resource wait configuration

### DIFF
--- a/datapusher/jobs.py
+++ b/datapusher/jobs.py
@@ -308,6 +308,17 @@ def push_to_datastore(task_id, input, dry_run=False):
             if try_index >= MAX_GET_RESOURCE_TRIES:
                 raise
 
+            logger.info(
+                'get_resource({}, {}) failed with error [{}]. ' \
+                'Retrying for {} more time(s) after {} seconds'.format(
+                    resource_id,
+                    ckan_url,
+                    e,
+                    (MAX_GET_RESOURCE_TRIES - try_index),
+                    sleep_before_get_resource_retry_in_seconds
+                )
+            )
+
             sleep(sleep_before_get_resource_retry_in_seconds)
             sleep_before_get_resource_retry_in_seconds *= 2
 

--- a/datapusher/jobs.py
+++ b/datapusher/jobs.py
@@ -309,17 +309,18 @@ def push_to_datastore(task_id, input, dry_run=False):
                 raise
 
             logger.info(
-                'get_resource({}, {}) failed with error [{}]. ' \
+                'get_resource({}, {}) failed with error type "{}" and message [{}]. ' \
                 'Retrying for {} more time(s) after {} seconds'.format(
                     resource_id,
                     ckan_url,
-                    e,
+                    type(e).__name__,
+                    unicode(e.message),
                     (MAX_GET_RESOURCE_TRIES - try_index),
                     sleep_before_get_resource_retry_in_seconds
                 )
             )
 
-            sleep(sleep_before_get_resource_retry_in_seconds)
+            time.sleep(sleep_before_get_resource_retry_in_seconds)
             sleep_before_get_resource_retry_in_seconds *= 2
 
     # fetch the resource data

--- a/datapusher/jobs.py
+++ b/datapusher/jobs.py
@@ -27,7 +27,7 @@ if not locale.getlocale()[0]:
     locale.setlocale(locale.LC_ALL, '')
 
 MAX_CONTENT_LENGTH = web.app.config.get('MAX_CONTENT_LENGTH') or 10485760
-DOWNLOAD_TIMEOUT = 30
+DOWNLOAD_TIMEOUT = web.app.config.get('DOWNLOAD_TIMEOUT') or 30
 
 _TYPE_MAPPING = {
     'String': 'text',


### PR DESCRIPTION
- Add configuration for DOWNLOAD_TIMEOUT
- Add configuration and retries logic for get_resource in push_to_datastore job. If the uploaded resource is too big or the server have huge load, this call was failing which produces a lot of errors in the log.