### PR TITLE
Override guessed types in config file

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -17,6 +17,7 @@ CKAN`_ and set up the `DataStore`_.
    ckan-config
    using
    debugging
+   type-override
 
 
 License

--- a/doc/type-override.rst
+++ b/doc/type-override.rst
@@ -1,0 +1,13 @@
+Type Overrides
+==============
+
+If the type detector does not correctly identify the types of your spreadsheet columns,
+you can override them in the config file based on the dataset name::
+
+    import messytables
+    TYPE_OVERRIDES = [{
+        'dataset': 'my_dataset',
+        'fields': {
+            'My Column': messytables.StringType,
+        }
+    }]


### PR DESCRIPTION
I have added a new config parameter TYPE_OVERRIDES where you can override
detected types by messytables. This is helpful when your spreadsheet is very large and messytables
only checks the first 1000 rows for guessing the types.

This is an initial implementation, comments what I could change are welcome.