### PR TITLE
Fixed syntax error on `cp` of datapusher.conf

### DIFF
--- a/doc/deployment.rst
+++ b/doc/deployment.rst
@@ -40,7 +40,7 @@ These instructions set up the |datapusher| webservice on Apache running on port
 
     #copy the standard Apache config file
     # (use deployment/datapusher.apache2-4.conf if you are running under Apache 2.4)
-    sudo cp deployment/datapusher.conf /etc/apache2/sites-available/datapusher.conf)
+    sudo cp deployment/datapusher.conf /etc/apache2/sites-available/datapusher.conf
 
     #copy the standard DataPusher wsgi file
     #(see note below if you are not using the default CKAN install location)


### PR DESCRIPTION
There was an end parenthesis that should not be there.