### PR TITLE
Use getdefaultlocale() to get the current locale

### DIFF
--- a/datapusher/jobs.py
+++ b/datapusher/jobs.py
@@ -23,7 +23,7 @@ import ckanserviceprovider.job as job
 import ckanserviceprovider.util as util
 from ckanserviceprovider import web
 
-if not locale.getlocale()[0]:
+if not locale.getdefaultlocale()[0]:
     locale.setlocale(locale.LC_ALL, '')
 
 MAX_CONTENT_LENGTH = web.app.config.get('MAX_CONTENT_LENGTH') or 10485760

--- a/datapusher/jobs.py
+++ b/datapusher/jobs.py
@@ -23,8 +23,9 @@ import ckanserviceprovider.job as job
 import ckanserviceprovider.util as util
 from ckanserviceprovider import web
 
-if not locale.getdefaultlocale()[0]:
-    locale.setlocale(locale.LC_ALL, '')
+if locale.getdefaultlocale()[0]:
+    lang, encoding = locale.getdefaultlocale()
+    locale.setlocale(locale.LC_ALL, '{0}.{1}'.format(lang, encoding))
 
 MAX_CONTENT_LENGTH = web.app.config.get('MAX_CONTENT_LENGTH') or 10485760
 DOWNLOAD_TIMEOUT = 30

--- a/datapusher/jobs.py
+++ b/datapusher/jobs.py
@@ -26,6 +26,8 @@ from ckanserviceprovider import web
 if locale.getdefaultlocale()[0]:
     lang, encoding = locale.getdefaultlocale()
     locale.setlocale(locale.LC_ALL, '{0}.{1}'.format(lang, encoding))
+else:
+    locale.setlocale(locale.LC_ALL, '')
 
 MAX_CONTENT_LENGTH = web.app.config.get('MAX_CONTENT_LENGTH') or 10485760
 DOWNLOAD_TIMEOUT = 30


### PR DESCRIPTION
Using getdefaultlocale() will get the default system locale, while getlocale() always returns (None, None)