### PR TITLE
Fix call to locale.setlocale in jobs module for old Python 2.7

### DIFF
--- a/datapusher/jobs.py
+++ b/datapusher/jobs.py
@@ -25,7 +25,7 @@ from ckanserviceprovider import web
 
 if locale.getdefaultlocale()[0]:
     lang, encoding = locale.getdefaultlocale()
-    locale.setlocale(locale.LC_ALL, '{0}.{1}'.format(lang, encoding))
+    locale.setlocale(locale.LC_ALL, locale=(lang, encoding))
 else:
     locale.setlocale(locale.LC_ALL, '')
 


### PR DESCRIPTION
In jobs, we have unicode literals so that `'{0}.{1}'.format(lang, encoding)`
is a unicode string in Python 2. This is causing problem with an old
version of Python's locale module (that in Python 2.7.5 on RedHat 7.2 for
instance) which would type-check this argument against basestring (see https://hg.python.org/cpython/file/v2.7.5/Lib/locale.py#l532 for the old version and https://hg.python.org/cpython/rev/7841e9b614eb for the fix).

So use pass the `locale` information as a tuple which should work in any Python2.7 version.