### PR TITLE
add security requirements-to-datapusher

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ ckanserviceprovider==0.0.5
 html5lib==0.9999999
 messytables==0.15.2
 python-slugify==1.2.1
-requests==2.13.0
+certifi
+requests[security]==2.13.0


### PR DESCRIPTION
Adding this extras-option to Requests will in particular make sure that certifi-package is used, if available. That way, a carefully curated collection of Root Certificates will be supported when checking for SSL verification.

PR #117 was accidentially closed. Sorry for the confusion it may cause.