### PR TITLE
Better error logs

### DIFF
--- a/datapusher/jobs.py
+++ b/datapusher/jobs.py
@@ -107,7 +107,9 @@ class HTTPError(util.JobError):
         }
 
     def __str__(self):
-        return self.message
+        return u'{} status={} url={} response={}'.format(
+            self.message, self.status_code, self.request_url, self.response) \
+            .encode('ascii', 'replace')
 
 
 def get_url(action, ckan_url):


### PR DESCRIPTION
When datapusher suffers an error doing a request (as is so common), the response is now logged. e.g.

`HTTPError: CKAN DataStore bad response. Status code: 409 Conflict. At: https://energydata.info/api/3/action/datastore_create. status=409 url=https://energydata.info/api/3/action/datastore_create response={"help": "https://energydata.info/api/3/action/help_show?name=datastore_create", "success": false, "error": {"records": ["row \"1\" has extra keys \"The wind measurement campaign that has generated this data was commissioned by The World Bank with funding from the Energy Sector Management Assistance Program (ESMAP). The data is made freely available under The World Bank?s open data policy.\""], "__type": "Validation Error"}}`

whereas previously it just showed `HTTP Error`, or with #119 it showed:

`HTTPError: CKAN DataStore bad response. Status code: 409 Conflict. At: https://energydata.info/api/3/action/datastore_create.`

This brings the logs into line with what is seen on the web interface (although without the response being truncated):

<img width="686" alt="screen shot 2017-03-10 at 09 45 05" src="https://cloud.githubusercontent.com/assets/307612/23790269/4e155fe2-0576-11e7-9dcc-bbb465214415.png">
