### PR TITLE
Use the latest version of ckanserviceprovider

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 argparse
-ckanserviceprovider==0.0.5
+ckanserviceprovider==0.0.6
 html5lib==0.9999999
 messytables==0.15.2
 python-slugify==1.2.1


### PR DESCRIPTION
This provides this fix: https://github.com/ckan/ckan-service-provider/pull/32
so that datapusher works with CKAN 2.7.

Fixes #124