### PR TITLE
Check MAX_CONTENT_LENGTH against downloaded file

### DIFF
--- a/datapusher/jobs.py
+++ b/datapusher/jobs.py
@@ -365,14 +365,21 @@ def push_to_datastore(task_id, input, dry_run=False):
                 request_url=resource.get('url'), response=None)
 
     cl = response.info().getheader('content-length')
+    content = None
     if cl and int(cl) > MAX_CONTENT_LENGTH:
         raise util.JobError(
             'Resource too large to download: {cl} > max ({max_cl}).'.format(
             cl=cl, max_cl=MAX_CONTENT_LENGTH))
+    else:
+        content = response.read()
+        if len(content) > MAX_CONTENT_LENGTH:
+            raise util.JobError(
+                'Resource too large to process: {cl} > max ({max_cl}).'.format(
+                cl=len(content), max_cl=MAX_CONTENT_LENGTH))
 
     ct = response.info().getheader('content-type').split(';', 1)[0]
 
-    f = cStringIO.StringIO(response.read())
+    f = cStringIO.StringIO(content)
     file_hash = hashlib.md5(f.read()).hexdigest()
     f.seek(0)
 

--- a/tests/test_acceptance.py
+++ b/tests/test_acceptance.py
@@ -104,6 +104,41 @@ class TestImport(unittest.TestCase):
 
     @httpretty.activate
     @raises(util.JobError)
+    def test_too_large_content_length(self):
+        """It should raise JobError if the returned Content-Length header 
+        is too large.
+
+        If the returned header is larger than MAX_CONTENT_LENGTH then the async
+        background job push_to_datastore should raise JobError
+        (ckanserviceprovider will catch this exception and return an error to
+        the client).
+
+        """
+        self.register_urls()
+        data = {
+            'api_key': self.api_key,
+            'job_type': 'push_to_datastore',
+            'metadata': {
+                'ckan_url': 'http://%s/' % self.host,
+                'resource_id': self.resource_id
+            }
+        }
+
+        # Override the source_url (already mocked by self.register_urls()
+        # above) with another mock response, this one mocks a response body
+        # that's bigger than MAX_CONTENT_LENGTH.
+        source_url = 'http://www.source.org/static/file'
+        size = jobs.MAX_CONTENT_LENGTH + 1
+        httpretty.register_uri(
+            httpretty.GET, source_url,
+            body='a' * size,
+            content_length=size,
+            content_type='application/json')
+
+        jobs.push_to_datastore('fake_id', data, True)
+
+    @httpretty.activate
+    @raises(util.JobError)
     def test_too_large_file(self):
         """It should raise JobError if the data file is too large.
 
@@ -131,8 +166,10 @@ class TestImport(unittest.TestCase):
         httpretty.register_uri(
             httpretty.GET, source_url,
             body='a' * size,
-            content_length=size,
-            content_type='application/json')
+            content_type='application/json',
+            forcing_headers={
+                'content-length': 0
+            })
 
         jobs.push_to_datastore('fake_id', data, True)
 

--- a/tests/test_acceptance.py
+++ b/tests/test_acceptance.py
@@ -168,7 +168,7 @@ class TestImport(unittest.TestCase):
             body='a' * size,
             content_type='application/json',
             forcing_headers={
-                'content-length': 0
+                'content-length': ''
             })
 
         jobs.push_to_datastore('fake_id', data, True)


### PR DESCRIPTION
This is important if the server did not provide the Content-Length
header in the response, but you still want to discard files, that are
too large.