### PR TITLE
Use requests to download files instead of urllib2 AND extend SSL_VERIFY option to these requests (for testing)

### DIFF
--- a/datapusher/jobs.py
+++ b/datapusher/jobs.py
@@ -354,6 +354,7 @@ def push_to_datastore(task_id, input, dry_run=False):
             url,
             headers=headers,
             timeout=DOWNLOAD_TIMEOUT,
+            verify=SSL_VERIFY,
             stream=True,  # just gets the headers for now
             )
         response.raise_for_status()

--- a/datapusher/jobs.py
+++ b/datapusher/jobs.py
@@ -359,7 +359,7 @@ def push_to_datastore(task_id, input, dry_run=False):
             )
         response.raise_for_status()
 
-        cl = response.headers['content-length']
+        cl = response.headers.get('content-length')
         if cl and int(cl) > MAX_CONTENT_LENGTH:
             raise util.JobError(
                 'Resource too large to download: {cl} > max ({max_cl}).'

--- a/datapusher/jobs.py
+++ b/datapusher/jobs.py
@@ -2,7 +2,6 @@
 from __future__ import unicode_literals
 
 import json
-import urllib2
 import socket
 import requests
 import urlparse
@@ -335,58 +334,60 @@ def push_to_datastore(task_id, input, dry_run=False):
         logger.info('Dump files are managed with the Datastore API')
         return
 
+    # check scheme
+    url = resource.get('url')
+    scheme = urlparse.urlsplit(url).scheme
+    if scheme not in ('http', 'https', 'ftp'):
+        raise util.JobError(
+            'Only http, https, and ftp resources may be fetched.'
+        )
+
     # fetch the resource data
-    logger.info('Fetching from: {0}'.format(resource.get('url')))
+    logger.info('Fetching from: {0}'.format(url))
+    headers = {}
+    if resource.get('url_type') == 'upload':
+        # If this is an uploaded file to CKAN, authenticate the request,
+        # otherwise we won't get file from private resources
+        headers['Authorization'] = api_key
     try:
-        request = urllib2.Request(resource.get('url'))
-        
-        if request.get_type().lower() not in ('http', 'https', 'ftp'):
-            raise util.JobError(
-                'Only http, https, and ftp resources may be fetched.'
+        response = requests.get(
+            url,
+            headers=headers,
+            timeout=DOWNLOAD_TIMEOUT,
+            verify=SSL_VERIFY,
+            stream=True,  # just gets the headers for now
             )
+        response.raise_for_status()
 
-        if resource.get('url_type') == 'upload':
-            # If this is an uploaded file to CKAN, authenticate the request,
-            # otherwise we won't get file from private resources
-            request.add_header('Authorization', api_key)
+        cl = response.headers['content-length']
+        if cl and int(cl) > MAX_CONTENT_LENGTH:
+            raise util.JobError(
+                'Resource too large to download: {cl} > max ({max_cl}).'
+                .format(cl=cl, max_cl=MAX_CONTENT_LENGTH))
 
-        response = urllib2.urlopen(request, timeout=DOWNLOAD_TIMEOUT)
-    except urllib2.HTTPError as e:
+        tmp = tempfile.TemporaryFile()
+        length = 0
+        m = hashlib.md5()
+        for chunk in response.iter_content(CHUNK_SIZE):
+            length += len(chunk)
+            if length > MAX_CONTENT_LENGTH:
+                raise util.JobError(
+                    'Resource too large to process: {cl} > max ({max_cl}).'
+                    .format(cl=length, max_cl=MAX_CONTENT_LENGTH))
+            tmp.write(chunk)
+            m.update(chunk)
+
+        ct = response.headers.get('content-type', '').split(';', 1)[0]
+
+    except requests.HTTPError as e:
         raise HTTPError(
             "DataPusher received a bad HTTP response when trying to download "
-            "the data file", status_code=e.code,
-            request_url=resource.get('url'), response=e.read())
-    except urllib2.URLError as e:
-        if isinstance(e.reason, socket.timeout):
-            raise util.JobError('Connection timed out after %ss' %
-                                DOWNLOAD_TIMEOUT)
-        else:
-            raise HTTPError(
-                message=str(e.reason), status_code=None,
-                request_url=resource.get('url'), response=None)
-
-    cl = response.info().getheader('content-length')
-    if cl and int(cl) > MAX_CONTENT_LENGTH:
-        raise util.JobError(
-            'Resource too large to download: {cl} > max ({max_cl}).'.format(
-            cl=cl, max_cl=MAX_CONTENT_LENGTH))
-
-    tmp = tempfile.TemporaryFile()
-    length = 0
-    m = hashlib.md5()
-    while True:
-        chunk = response.read(CHUNK_SIZE)
-        if not chunk:
-            break
-        length += len(chunk) 
-        if length > MAX_CONTENT_LENGTH:
-            raise util.JobError(
-                'Resource too large to process: {cl} > max ({max_cl}).'.format(
-                cl=length, max_cl=MAX_CONTENT_LENGTH))
-        tmp.write(chunk)
-        m.update(chunk)
-
-    ct = response.info().getheader('content-type').split(';', 1)[0]
+            "the data file", status_code=e.response.status_code,
+            request_url=url, response=e.response.content)
+    except requests.RequestException as e:
+        raise HTTPError(
+            message=str(e), status_code=None,
+            request_url=url, response=None)
 
     file_hash = m.hexdigest()
     tmp.seek(0)

--- a/datapusher/jobs.py
+++ b/datapusher/jobs.py
@@ -354,7 +354,6 @@ def push_to_datastore(task_id, input, dry_run=False):
             url,
             headers=headers,
             timeout=DOWNLOAD_TIMEOUT,
-            verify=SSL_VERIFY,
             stream=True,  # just gets the headers for now
             )
         response.raise_for_status()

--- a/doc/using.rst
+++ b/doc/using.rst
@@ -70,18 +70,25 @@ You can specify the types to use with the following settings in your datapusher_
 Configuring SSL verification
 ----------------------------
 
-By default the ``datapusher`` will verify that a valid SSL certificate is in
-place on every request it does. This can be problematic, because the list of
-valid root certificates gets out of date. The suggested fix is to use the latest
-version of ``requests`` and its 'security' addition::
+Assuming CKAN is served on HTTPS (rather than HTTP), then by default
+``datapusher`` will verify that CKAN has a valid SSL/TLS certificate. However
+the default list of root certificate is usually held by the operating system,
+and often gets out of date, causing SSL verification errors. (Browsers usually
+have their own list and update it frequently.)
+
+The suggested fix is to use the latest version of ``requests`` and its
+'security' addition::
 
     pip install -U requests[security]
 
-There are no known compatibility issues with ckan or common extensions by using
-a more recent version of requests. (However requests.txt still pins the version,
-as per the ckan policy.)
+There are no known compatibility issues with CKAN or common extensions by using
+a more recent version of requests. (However requirements.txt still pins the
+version, as per the ckan policy.)
 
-If it should still be a problem, you can switch the verification off if needed
-by setting SSL_VERIFY to False in datapusher_settings.py::
+If you still have problems verifying certificates, you can switch the
+verification off in datapusher_settings.py::
 
     SSL_VERIFY = False
+
+Note there is an ongoing issue with this option:
+https://github.com/ckan/datapusher/issues/149

--- a/doc/using.rst
+++ b/doc/using.rst
@@ -70,11 +70,11 @@ You can specify the types to use with the following settings in your datapusher_
 Configuring SSL verification
 ----------------------------
 
-Assuming CKAN is served on HTTPS (rather than HTTP), then by default
-``datapusher`` will verify that CKAN has a valid SSL/TLS certificate. However
-the default list of root certificate is usually held by the operating system,
-and often gets out of date, causing SSL verification errors. (Browsers usually
-have their own list and update it frequently.)
+By default ``datapusher`` will verify that requests to CKAN and other servers
+with HTTPS are with a valid SSL/TLS certificate. However the default list of
+root certificates is usually held by the operating system, and often gets out of
+date, causing SSL verification errors. (Browsers usually have their own list and
+update it frequently.)
 
 The suggested fix is to use the latest version of ``requests`` and its
 'security' addition::
@@ -85,8 +85,8 @@ There are no known compatibility issues with CKAN or common extensions by using
 a more recent version of requests. (However requirements.txt still pins the
 version, as per the ckan policy.)
 
-If you still have problems verifying certificates, you can switch the
-verification off in datapusher_settings.py::
+If you still have problems verifying certificates, or maybe for test purposes,
+you can switch the verification off in datapusher_settings.py::
 
     SSL_VERIFY = False
 

--- a/tests/test_acceptance.py
+++ b/tests/test_acceptance.py
@@ -14,9 +14,10 @@ import os
 import json
 import unittest
 import datetime
-from nose.tools import assert_equal, raises
 
+from nose.tools import assert_equal, raises
 import httpretty
+import requests
 
 import datapusher.main as main
 import datapusher.jobs as jobs
@@ -401,6 +402,28 @@ class TestImport(unittest.TestCase):
 
         """
         self.register_urls(source_url='http://url-badly-formed')
+        data = {
+            'api_key': self.api_key,
+            'job_type': 'push_to_datastore',
+            'metadata': {
+                'ckan_url': 'http://%s/' % self.host,
+                'resource_id': self.resource_id
+            }
+        }
+
+        jobs.push_to_datastore('fake_id', data, True)
+
+    @raises(util.JobError)
+    @httpretty.activate
+    def test_bad_scheme(self):
+        """It should raise HTTPError(JobError) if the resource.url is an
+        invalid scheme.
+
+        (ckanserviceprovider will catch this exception and return an error to
+        the client).
+
+        """
+        self.register_urls(source_url='invalid://example.com')
         data = {
             'api_key': self.api_key,
             'job_type': 'push_to_datastore',


### PR DESCRIPTION
It seems a no-brainer to use requests instead of urllib2 for this key step of downloading the data file that gets pushed because requests is superior in lots of ways.

[Since python 2.7.9, urllib2 went from not verifying certificates at all to verifying them against the OS's built-in list](https://stackoverflow.com/a/28325763). My experience of the latter is that it goes out of date and even big sites like github.com start getting rejected. Requests handles this much better imo because it updates more frequently via the certifi python module (installed with `requests[security]`. I've used this in ckanext-archiver in a similar for several years with success, but successfully checking HTTPS certs.

I've checked the tests pass, but it's not tried in production or battle-hardened, so could do with double-checking.