### PR TITLE
add False and 0 as possible values for SSL_VERIFY-option

### DIFF
--- a/datapusher/jobs.py
+++ b/datapusher/jobs.py
@@ -32,7 +32,7 @@ MAX_CONTENT_LENGTH = web.app.config.get('MAX_CONTENT_LENGTH') or 10485760
 CHUNK_SIZE = 16 * 1024 # 16kb
 DOWNLOAD_TIMEOUT = 30
 
-if web.app.config.get('SSL_VERIFY') in ['False', 'FALSE', '0']:
+if web.app.config.get('SSL_VERIFY') in ['False', 'FALSE', '0', False, 0]:
     SSL_VERIFY = False
 else:
     SSL_VERIFY = True

--- a/doc/using.rst
+++ b/doc/using.rst
@@ -89,6 +89,3 @@ If you still have problems verifying certificates, or maybe for test purposes,
 you can switch the verification off in datapusher_settings.py::
 
     SSL_VERIFY = False
-
-Note there is an ongoing issue with this option:
-https://github.com/ckan/datapusher/issues/149


### PR DESCRIPTION
As discussed here: https://github.com/ckan/datapusher/pull/109#discussion_r102938501
we check if SSL_VERIFY by comparing it to several possibilities of assigning it to false. ('False', 'FALSE', '0', False and 0)

This would fix https://github.com/ckan/datapusher/issues/149