### PR TITLE
Calculate record count

### DIFF
--- a/datapusher/jobs.py
+++ b/datapusher/jobs.py
@@ -256,23 +256,6 @@ def send_resource_to_datastore(resource, headers, records,
     check_response(r, url, 'CKAN DataStore')
 
 
-def run_analyze(resource, api_key, ckan_url):
-    """
-    Tells CKAN datastore to run ANALYZE on the table
-    """
-    params = {'resource_id': resource['id']}
-
-    name = resource.get('name')
-    url = get_url('datastore_analyze', ckan_url)
-    r = requests.post(url,
-                      verify=SSL_VERIFY,
-                      data=json.dumps(params),
-                      headers={'Content-Type': 'application/json',
-                               'Authorization': api_key}
-                      )
-    check_response(r, url, 'CKAN DataStore')
-
-
 def update_resource(resource, api_key, ckan_url):
     """
     Update webstore_url and webstore_last_updated in CKAN

--- a/datapusher/jobs.py
+++ b/datapusher/jobs.py
@@ -515,7 +515,8 @@ def push_to_datastore(task_id, input, dry_run=False):
     for i, chunk in enumerate(chunky(result, 250)):
         records, is_it_the_last_chunk = chunk
         count += len(records)
-        logger.info('Saving chunk {number}'.format(number=i))
+        logger.info('Saving chunk {number} {is_last}'.format(
+            number=i, is_last='(last)' if is_it_the_last_chunk else ''))
         send_resource_to_datastore(resource, headers_dicts, records,
                                    is_it_the_last_chunk, api_key, ckan_url)
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -15,12 +15,33 @@ import datapusher.jobs as jobs
 import ckanserviceprovider.util as util
 
 
-class TestChuncky(unittest.TestCase):
-    def test_chuncky(self):
-        r = jobs.chunky('abcdefg', 3)
-        l = list(r)
-        assert_equal(l, [['a', 'b', 'c'], ['d', 'e', 'f'], ['g']])
+class TestChunky():
+    def test_simple(self):
+        chunks = jobs.chunky('abcdefg', 3)
+        assert_equal(
+            list(chunks),
+            [
+                (['a', 'b', 'c'], False),
+                (['d', 'e', 'f'], False),
+                (['g'], True)
+             ])
 
+    def test_length_is_the_exact_multiple(self):
+        chunks = jobs.chunky('abcdef', 3)
+        assert_equal(
+            list(chunks),
+            [
+                (['a', 'b', 'c'], False),
+                (['d', 'e', 'f'], True),
+             ])
+
+    def test_empty(self):
+        chunks = jobs.chunky('', 3)
+        assert_equal(
+            list(chunks), [])
+
+
+class TestGetUrl():
     def test_get_action_url(self):
         assert_equal(
             jobs.get_url('datastore_create', 'http://www.ckan.org'),
@@ -140,7 +161,7 @@ class TestCkanActionCalls(unittest.TestCase):
         httpretty.register_uri(httpretty.POST, url,
                                body=u'{"success": true}',
                                content_type="application/json")
-        jobs.send_resource_to_datastore({'id': 'an_id'}, [], [], 'my_key', 'http://www.ckan.org/')
+        jobs.send_resource_to_datastore({'id': 'an_id'}, [], [], False, 'my_key', 'http://www.ckan.org/')
 
 
 class TestCheckResponse(unittest.TestCase):


### PR DESCRIPTION
Compatibility with: https://github.com/ckan/ckan/pull/4473.

Now when it pushes the last chunk it sets calculate_record_count=True and datastore will do an ANALYZE, which stores a count of the rows, so that when a user previews the resource this count can be used instead of a more expensive SELECT COUNT(*) at load-time.

Together these 2 PRs will speed up viewing large resources. Nothing breaks if you update one but not the other.