### PR TITLE
fix: py3 support

### DIFF
--- a/deployment/datapusher.wsgi
+++ b/deployment/datapusher.wsgi
@@ -3,7 +3,8 @@ import sys
 import hashlib
 
 activate_this = os.path.join('/usr/lib/ckan/datapusher/bin/activate_this.py')
-execfile(activate_this, dict(__file__=activate_this))
+with open(activate_this) as fp:
+    exec(fp.read(), dict(__file__=activate_this))
 
 import ckanserviceprovider.web as web
 os.environ['JOB_CONFIG'] = '/etc/ckan/datapusher_settings.py'


### PR DESCRIPTION
https://docs.python.org/3.3/whatsnew/3.0.html?highlight=execfile#builtins

> Removed execfile(). Instead of execfile(fn) use exec(open(fn).read()).