### PR TITLE
Prevent wrong utf-8 encoding

### DIFF
--- a/datapusher/jobs.py
+++ b/datapusher/jobs.py
@@ -466,7 +466,7 @@ def push_to_datastore(task_id, input, dry_run=False):
                 if isinstance(cell.value, str):
                     try:
                         data_row[column_name] = cell.value.encode('latin-1').decode('utf-8')
-                    except UnicodeDecodeError:
+                    except UnicodeDecodeError, UnicodeEncodeError:
                         data_row[column_name] = cell.value
                 else:
                     data_row[column_name] = cell.value

--- a/datapusher/jobs.py
+++ b/datapusher/jobs.py
@@ -466,7 +466,7 @@ def push_to_datastore(task_id, input, dry_run=False):
                 if isinstance(cell.value, str):
                     try:
                         data_row[column_name] = cell.value.encode('latin-1').decode('utf-8')
-                    except UnicodeEncodeError:
+                    except UnicodeDecodeError:
                         data_row[column_name] = cell.value
                 else:
                     data_row[column_name] = cell.value

--- a/datapusher/jobs.py
+++ b/datapusher/jobs.py
@@ -466,7 +466,7 @@ def push_to_datastore(task_id, input, dry_run=False):
                 if isinstance(cell.value, str):
                     try:
                         data_row[column_name] = cell.value.encode('latin-1').decode('utf-8')
-                    except UnicodeDecodeError, UnicodeEncodeError:
+                    except (UnicodeDecodeError, UnicodeEncodeError):
                         data_row[column_name] = cell.value
                 else:
                     data_row[column_name] = cell.value

--- a/datapusher/jobs.py
+++ b/datapusher/jobs.py
@@ -466,7 +466,7 @@ def push_to_datastore(task_id, input, dry_run=False):
                 if isinstance(cell.value, str):
                     try:
                         data_row[column_name] = cell.value.encode('latin-1').decode('utf-8')
-                    except:
+                    except UnicodeEncodeError:
                         data_row[column_name] = cell.value
                 else:
                     data_row[column_name] = cell.value

--- a/datapusher/jobs.py
+++ b/datapusher/jobs.py
@@ -463,7 +463,13 @@ def push_to_datastore(task_id, input, dry_run=False):
                 column_name = cell.column.strip()
                 if column_name not in headers_set:
                     continue
-                data_row[column_name] = cell.value
+                if isinstance(cell.value, str):
+                    try:
+                        data_row[column_name] = cell.value.encode('latin-1').decode('utf-8')
+                    except:
+                        data_row[column_name] = cell.value
+                else:
+                    data_row[column_name] = cell.value
             yield data_row
     result = row_iterator()
 


### PR DESCRIPTION
The encoding issue was due to Latin char that is converted by the `requests` module `iter_content`.

Fixes ckan/ckan#5434