### PR TITLE
Py3 argparser fix

### DIFF
--- a/datapusher/main.py
+++ b/datapusher/main.py
@@ -2,7 +2,7 @@ import os
 import six
 import ckanserviceprovider.web as web
 
-from . import jobs
+from datapusher import jobs
 
 # check whether jobs have been imported properly
 assert(jobs.push_to_datastore)

--- a/datapusher/main.py
+++ b/datapusher/main.py
@@ -1,5 +1,5 @@
 import os
-
+import six
 import ckanserviceprovider.web as web
 
 from . import jobs
@@ -25,9 +25,12 @@ def main():
         description='Service that allows automatic migration of data to the CKAN DataStore',
         epilog='''"He reached out and pressed an invitingly large red button on a nearby panel.
                 The panel lit up with the words Please do not press this button again."''')
-
-    argparser.add_argument('config', metavar='CONFIG', type=file,
-                           help='configuration file')
+    if six.PY3:
+        argparser.add_argument('config', metavar='CONFIG', type=argparse.FileType('r'),
+                            help='configuration file')
+    if six.PY2:
+        argparser.add_argument('config', metavar='CONFIG', type=file,
+                            help='configuration file')
     args = argparser.parse_args()
 
     os.environ['JOB_CONFIG'] = os.path.abspath(args.config.name)


### PR DESCRIPTION
Argparse has removed the `type=file` support in Py3.

https://docs.python.org/3/library/argparse.html#type

Using six to validate the python version and then using argparse accordingly.