### PR TITLE
Dockerfile setup with Travis CI check and documentation update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: python
+services:
+  - docker
 python:
   - "2.7"
   - "3.6"
@@ -11,3 +13,14 @@ install:
 script: nosetests --with-coverage --cover-package=datapusher
 after_success:
   - coveralls
+
+jobs:
+  include:
+    - stage: docker
+      python: "3.7"
+      install:
+        - docker build -t ckan/datapusher .
+        - docker run -d -p 127.0.0.1:8800:8800 --name datapusher ckan/datapusher
+      script:
+        - docker ps | grep -q datapusher
+        - curl --fail http://localhost:8800/job

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,106 @@
+#############
+### Build ###
+#############
+FROM alpine:3.12 as build
+
+# Set src dirs
+ENV SRC_DIR=/srv/app/src
+ENV PIP_SRC=${SRC_DIR}
+
+WORKDIR ${SRC_DIR}
+
+# Packages to build datapusher
+RUN apk add --no-cache \
+        python3 \
+        curl \
+        gcc \
+        make \
+        g++ \
+        autoconf \
+        automake \
+        libtool \
+        git \
+        musl-dev \
+        python3-dev \
+        libffi-dev \
+        openssl-dev \
+        pcre-dev \
+        libxml2-dev \
+        libxslt-dev
+
+# Create the src directory
+RUN mkdir -p ${SRC_DIR}
+
+# Copy datapusher to SRC_DIR
+COPY ./README.md ${SRC_DIR}/README.md
+COPY ./setup.py ${SRC_DIR}/setup.py
+COPY ./requirements.txt ${SRC_DIR}/requirements.txt
+COPY ./datapusher ${SRC_DIR}/datapusher
+
+# Install pip
+RUN curl -o ${SRC_DIR}/get-pip.py https://bootstrap.pypa.io/get-pip.py && \
+    python3 ${SRC_DIR}/get-pip.py
+
+# Fetch and build datapusher and requirements
+RUN pip wheel --wheel-dir=/wheels .
+RUN pip wheel --wheel-dir=/wheels -r requirements.txt
+
+# Copy requirements.txt to /wheels
+RUN cp requirements.txt /wheels/requirements.txt
+
+# Get uwsgi
+RUN pip wheel --wheel-dir=/wheels uwsgi==2.0.19.1
+
+
+############
+### MAIN ###
+############
+FROM alpine:3.12
+
+MAINTAINER Keitaro Inc <info@keitaro.com>
+
+ENV APP_DIR=/usr/lib/ckan/datapusher
+ENV WSGI_FILE ${APP_DIR}/src/datapusher/deployment/datapusher.wsgi
+ENV WSGI_CONFIG ${APP_DIR}/datapusher-uwsgi.ini
+
+COPY ./deployment/datapusher.wsgi ${WSGI_FILE}
+COPY ./deployment/datapusher-uwsgi.ini ${WSGI_CONFIG}
+
+WORKDIR ${APP_DIR}
+
+RUN apk add --no-cache \
+        python3 \
+        curl \
+        pcre \
+        libmagic \
+        libxslt \
+        libxml2
+
+# Get artifacts from build stages
+COPY --from=build /wheels /wheels
+
+# Create a local user and group to run the app
+RUN addgroup -g 92 -S www-data && \
+    adduser -u 92 -h ${APP_DIR} -H -D -S -G www-data www-data && \
+    # Setup a virtualenv
+    python3 -m venv ${APP_DIR} && \
+    ln -s /usr/lib/ckan/datapusher/bin/pip /usr/bin/pip && \
+    # Install uwsgi
+    pip install --no-index --find-links=/wheels uwsgi && \
+    # Install datapusher
+    pip install --no-index --find-links=/wheels datapusher && \
+    pip install --no-index --find-links=/wheels -r /wheels/requirements.txt && \
+    # Set timezone
+    echo "UTC" >  /etc/timezone && \
+    # Change uwsgi http worker to listen on all interfaces
+    sed 's/127.0.0.1/0.0.0.0/g' -i ${APP_DIR}/datapusher-uwsgi.ini && \
+    # Change ownership to app user
+    chown -R www-data:www-data ${APP_DIR} && \
+    # Remove wheels
+    rm -rf /wheels
+
+EXPOSE 8800
+
+USER www-data
+
+CMD $APP_DIR/bin/uwsgi -i $WSGI_CONFIG

--- a/README.md
+++ b/README.md
@@ -148,6 +148,17 @@ The default DataPusher configuration uses SQLite as the backend for the jobs dat
 	lazy-apps       =  true
     ```
 
+## Docker
+
+The repository contains a `Dockerfile` which is used to build a docker image for datapusher. Usage:
+```bash
+docker build -t mynamespace/datapusher .
+docker run -p 8800:8800 mynamespace/datapusher
+```
+
+In case you want to use the docker image for production deployments, it's important to take into account the [Production deployment](#production-deployment) considerations and modify your `Dockerfile`, `deployment/datapusher-uwsgi.ini` and `deployment/datapusher_settings.py` accordingly.
+
+
 ## Configuring
 
 


### PR DESCRIPTION
Fixes #110 
Fixes #136 
Fixes #163 

Considering datapusher is pretty-much a standalone component, it makes sense to include a Dockerfile, which can easily be extended to support all kinds of docker based deployment scenarios. The dockerfile is based on Alpine and it's using a multistage approach. Also to ensure that it doesn't break a CI test is included in Travis and basic docs.