### PR TITLE
Datapusher COPY mode

### DIFF
--- a/datapusher/jobs.py
+++ b/datapusher/jobs.py
@@ -550,12 +550,12 @@ def push_to_datastore(task_id, input, dry_run=False):
             delimiter = ','
 
         # now copy from file
+        rowcount = 0
         try:
             raw_connection = psycopg2.connect(COPY_WRITE_ENGINE_URL)
         except psycopg2.Error as e:
             error_str = str(e)
             logger.warning(error_str)
-            rowcount = 0
         else:
             cur = raw_connection.cursor()
             # we truncate table to use copy freeze option and further increase

--- a/datapusher/jobs.py
+++ b/datapusher/jobs.py
@@ -567,13 +567,12 @@ def push_to_datastore(task_id, input, dry_run=False):
             cur.execute('TRUNCATE TABLE \"{resource_id}\";'.format(resource_id=resource_id))
 
             copy_sql = ("COPY \"{resource_id}\" ({column_names}) FROM STDIN "
-                        "WITH (DELIMITER '{delimiter}', FORMAT csv, FREEZE 1, "
-                        "HEADER 1, ENCODING '{encoding}');").format(
+                        "WITH (DELIMITER '{delimiter}', FORMAT CSV, FREEZE 1, "
+                        "HEADER 1, ENCODING 'UTF8');").format(
                             resource_id=resource_id,
                             column_names=', '.join(['"{}"'.format(h['id'])
                                                     for h in headers_dicts]),
-                            delimiter=delimiter,
-                            encoding='UTF8')
+                            delimiter=delimiter)
             logger.info(copy_sql)
             with open(tmp.name, 'rb') as f:
                 try:
@@ -584,6 +583,7 @@ def push_to_datastore(task_id, input, dry_run=False):
                     rowcount = cur.rowcount
 
             raw_connection.commit()
+            # this is needed to issue a VACUUM ANALYZE
             raw_connection.set_isolation_level(psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT)
             cur = raw_connection.cursor()
             logger.info('Vacuum Analyzing table...')

--- a/datapusher/jobs.py
+++ b/datapusher/jobs.py
@@ -262,12 +262,12 @@ def send_resource_to_datastore(resource, headers, api_key, ckan_url,
     check_response(r, url, 'CKAN DataStore')
 
 
-def update_resource(resource, api_key, ckan_url, url_type):
+def update_resource(resource, api_key, ckan_url):
     """
     Update webstore_url and webstore_last_updated in CKAN
     """
 
-    resource['url_type'] = url_type
+    resource['url_type'] = 'datapusher'
 
     url = get_url('resource_update', ckan_url)
     r = requests.post(
@@ -528,7 +528,7 @@ def push_to_datastore(task_id, input, dry_run=False):
             n='{:,}'.format(count), res_id=resource_id, elapsed='{:,.2f}'.format(elapsed)))
 
         if data.get('set_url_type', False):
-            update_resource(resource, api_key, ckan_url, 'datapusher')
+            update_resource(resource, api_key, ckan_url)
     else:
         # use Postgres COPY so its much faster
         logger.info('Copying to database...')
@@ -594,6 +594,6 @@ def push_to_datastore(task_id, input, dry_run=False):
             n='{:,}'.format(rowcount), res_id=resource_id, elapsed='{:,.2f}'.format(elapsed)))
 
         resource['datastore_active'] = True
-        update_resource(resource, api_key, ckan_url, 'upload')
+        update_resource(resource, api_key, ckan_url)
 
     tmp.close()  # close temporary file

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ html5lib==1.0.1
 messytables==0.15.2
 certifi
 requests[security]==2.24.0
+psycopg2
+six


### PR DESCRIPTION
Resolves #220.

When a queued file's size is > `COPY_MODE_SIZE` (bytes) and a `COPY_ENGINE_WRITE_URL` is specified, datapusher uses Postgres COPY, similar to xloader, otherwise, use existing datapusher logic.

The main difference being, that we still use messytables to guess the column data types, which xloader currently doesn't do.

Also fixes #219, as the Datastore message is now more informative.

![datapusher-copy](https://user-images.githubusercontent.com/1980690/103469206-cba01600-4d2f-11eb-8f4f-2d940055029b.png)


