### PR TITLE
Support replaceable ckan host

### DIFF
--- a/datapusher/jobs.py
+++ b/datapusher/jobs.py
@@ -231,7 +231,7 @@ def datastore_resource_exists(resource_id, api_key, ckan_url):
         else:
             raise HTTPError(
                 'Error getting datastore resource.',
-                response.status_code, search_url, response,
+                response.status_code, search_url, response.text,
             )
     except requests.exceptions.RequestException as e:
         raise util.JobError(

--- a/datapusher/jobs.py
+++ b/datapusher/jobs.py
@@ -4,9 +4,9 @@
 import json
 import requests
 try:
-    from urllib.parse import urlsplit
+    from urllib.parse import urlsplit, urlparse, urlunparse
 except ImportError:
-    from urlparse import urlsplit
+    from urlparse import urlsplit, urlparse, urlunparse
 
 import itertools
 import datetime
@@ -350,6 +350,13 @@ def push_to_datastore(task_id, input, dry_run=False):
 
     # check scheme
     url = resource.get('url')
+    
+    # replace hostname in url
+    if config.get('ckanext.datapusher.ckan_host'):
+        ckan_host = config.get('ckanext.datapusher.ckan_host')
+        url_parse_reseult = urlparse(url)
+        url = urlunparse(url_parse_reseult._replace(netloc=ckan_host))
+
     scheme = urlsplit(url).scheme
     if scheme not in ('http', 'https', 'ftp'):
         raise util.JobError(

--- a/datapusher/jobs.py
+++ b/datapusher/jobs.py
@@ -350,7 +350,13 @@ def push_to_datastore(task_id, input, dry_run=False):
 
     # check scheme
     url = resource.get('url')
-    
+
+    # replace scheme in url
+    if web.app.config.get('CKAN_SCHEME'):
+        ckan_scheme = web.app.config.get('CKAN_SCHEME')
+        url_parse_reseult = urlparse(url)
+        url = urlunparse(url_parse_reseult._replace(scheme=ckan_scheme))
+
     # replace hostname in url
     if web.app.config.get('CKAN_HOSTNAME'):
         ckan_host = web.app.config.get('CKAN_HOSTNAME')

--- a/datapusher/jobs.py
+++ b/datapusher/jobs.py
@@ -352,8 +352,8 @@ def push_to_datastore(task_id, input, dry_run=False):
     url = resource.get('url')
     
     # replace hostname in url
-    if config.get('ckanext.datapusher.ckan_host'):
-        ckan_host = config.get('ckanext.datapusher.ckan_host')
+    if web.app.config.get('CKAN_HOSTNAME'):
+        ckan_host = web.app.config.get('CKAN_HOSTNAME')
         url_parse_reseult = urlparse(url)
         url = urlunparse(url_parse_reseult._replace(netloc=ckan_host))
 

--- a/deployment/datapusher_settings.py
+++ b/deployment/datapusher_settings.py
@@ -1,8 +1,8 @@
 import os
 import uuid
 
-DEBUG = False
-TESTING = False
+DEBUG = True if os.environ.get('DEBUG') else False
+TESTING = True if os.environ.get('TESTING') else False
 SECRET_KEY = str(uuid.uuid4())
 USERNAME = str(uuid.uuid4())
 PASSWORD = str(uuid.uuid4())
@@ -30,3 +30,5 @@ SSL_VERIFY = os.environ.get('DATAPUSHER_SSL_VERIFY', True)
 
 # logging
 #LOG_FILE = '/tmp/ckan_service.log'
+
+CKAN_HOSTNAME = os.environ.get('CKAN_HOSTNAME')

--- a/deployment/datapusher_settings.py
+++ b/deployment/datapusher_settings.py
@@ -31,4 +31,5 @@ SSL_VERIFY = os.environ.get('DATAPUSHER_SSL_VERIFY', True)
 # logging
 #LOG_FILE = '/tmp/ckan_service.log'
 
+CKAN_SCHEME = os.environ.get('CKAN_SCHEME')
 CKAN_HOSTNAME = os.environ.get('CKAN_HOSTNAME')


### PR DESCRIPTION
Relating: https://github.com/ckan/ckanext-xloader/pull/144

In docker environment, I want to replace the hostname in the url parameter in a object returned from `/api/3/action/resource_show`.

This pull request enables it from the environment variable `CKAN_HOSTNAME`.