### PR TITLE
Fix error handling in datastore_resource_exists method

### DIFF
--- a/datapusher/jobs.py
+++ b/datapusher/jobs.py
@@ -231,7 +231,7 @@ def datastore_resource_exists(resource_id, api_key, ckan_url):
         else:
             raise HTTPError(
                 'Error getting datastore resource.',
-                response.status_code, search_url, response,
+                response.status_code, search_url, response.text,
             )
     except requests.exceptions.RequestException as e:
         raise util.JobError(


### PR DESCRIPTION
An error handling in this line causes exception. The fourth argument of `HTTPError` should be string-like object.

https://github.com/ckan/datapusher/blob/master/datapusher/jobs.py#L234