### PR TITLE
Get debug and testing settings from environment variables

### DIFF
--- a/deployment/datapusher_settings.py
+++ b/deployment/datapusher_settings.py
@@ -1,8 +1,8 @@
 import os
 import uuid
 
-DEBUG = False
-TESTING = False
+DEBUG = True if os.environ.get('DEBUG') else False
+TESTING = True if os.environ.get('TESTING') else False
 SECRET_KEY = str(uuid.uuid4())
 USERNAME = str(uuid.uuid4())
 PASSWORD = str(uuid.uuid4())


### PR DESCRIPTION
In a docker environment, I hope to pass settings from environment variables.

But `DEBUG` and `TESTING` settings are fixed values in `datapusher_settings.py`.

I made them configurable from environment variables.