### PR TITLE
allow override of config file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,11 @@ integation. Please refer to the [DataPusher Settings](https://docs.ckan.org/en/l
 
 ### DataPusher Configuration
 
-The DataPusher instance is configured in the `deployment/datapusher_settings.py` file.
+The DataPusher instance is configured in the `deployment/datapusher_settings.py`
+file. The location of this file can be adjusted using the `JOB_CONFIG`
+environment variable which should provide an absolute path to a python-formatted
+config file.
+
 Here's a summary of the options available.
 
 | Name | Default | Description |

--- a/deployment/datapusher.wsgi
+++ b/deployment/datapusher.wsgi
@@ -4,7 +4,8 @@ import ckanserviceprovider.web as web
 config_filepath = os.path.join(
     os.path.dirname(os.path.abspath(__file__)), 'datapusher_settings.py')
 
-os.environ['JOB_CONFIG'] = config_filepath
+if 'JOB_CONFIG' not in os.environ:
+    os.environ['JOB_CONFIG'] = config_filepath
 
 web.init()
 


### PR DESCRIPTION
In line with #246 this PR allows the config file to be overridden via the `JOB_CONFIG` environment variable.

The change is very simple and doesn't conflict with current setup, it just mandates that if the variable is set then it is not re-set to the default config file.

My motivation is that, while environment variables allow tuning of some parameters, managing them can become a burden and a config file persisted to disk might be easier.