### PR TITLE
update requirements : Werkzeug~=2.0.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ html5lib==1.0.1
 messytables==0.15.2
 certifi
 requests[security]==2.24.0
+Werkzeug~=2.0.2


### PR DESCRIPTION
else 2.1 raises
ImportError: cannot import name 'safe_str_cmp' from 'werkzeug.security'
https://stackoverflow.com/questions/71652965/importerror-cannot-import-name-safe-str-cmp-from-werkzeug-security