### PR TITLE
Revamped data type sniffing for CSV/TSV files

### DIFF
--- a/datapusher/jobs.py
+++ b/datapusher/jobs.py
@@ -414,7 +414,7 @@ def pandas_sniff_algorithm( tmp, ct, resource_id, api_key, ckan_url, ext='CSV' )
         raise util.JobError(e)
 
     # handle odd column names
-    if ('Unnamed: 0' in dataset.columns):
+    if (dataset.columns[0] == 'Unnamed: 0'):
         dataset.drop( ['Unnamed: 0'], axis=1, inplace=True )    # almost certainly an index column, thus redundant
 
     dataset.columns = [sanitize_column_name(x) for x in dataset.columns]    # rename the source!

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ html5lib==1.0.1
 messytables==0.15.2
 certifi
 requests[security]==2.27.1
+pandas


### PR DESCRIPTION
Based on: https://gitlab.com/hjhornbeck/datapusher/

This patch changes push_to_datastore() to use pandas for data sniffing CSV/TSV files instead of messytables. The last release of the latter library was about five years ago, and their git repository has been idle for three. In practice, I've found it has difficulties correctly detecting dates, hence the motivation to substitute another library.

In the process of adding that functionality, I've also done a number of small tweaks. Type sniffing is much more focused, taking more advantage of `int4` and `int8` formats to save space relative to `numeric`. CKAN and PostgreSQL reject a column name that contains a percent sign; a workaround to permit this has been implemented. If the dataset contains an columns with no name, pandas gives them the name "Unnamed: X." It is common for CSV files to have an unnamed index column as their first, which is redundant when CKAN adds its own index column; this code automatically deletes that column. The automatic data dictionary has been improved, the "description" field is now filled with a summary of the column's data. Text fields get special treatment, if a full list of the individual categories is less than a user-selectable limit then all of them are explicitly named in a format that's both human- and machine-readable.